### PR TITLE
Allowed wildcard for subdomains of incrementally.xyz

### DIFF
--- a/Startup.cs
+++ b/Startup.cs
@@ -58,21 +58,20 @@ namespace incrementally_backend
                     {
                         if (Env.IsDevelopment())
                         {
-                            builder.WithOrigins(
-                                "http://*.localhost:8080"
-                            )
+                            builder
                             .AllowAnyHeader()
-                            .AllowAnyMethod();
+                            .AllowAnyMethod()
+                            .AllowAnyOrigin();
                         }
                         else
                         {
                             builder.WithOrigins(
-                                "https://*.incrementally.xyz"
+                                "https://incrementally.xyz",
+                                "https://www.incrementally.xyz"
                             )
                             .AllowAnyHeader()
                             .AllowAnyMethod();
                         }
-                        builder.SetIsOriginAllowedToAllowWildcardSubdomains();
                     });
             });
             services.AddSwaggerGen(c =>

--- a/Startup.cs
+++ b/Startup.cs
@@ -59,8 +59,7 @@ namespace incrementally_backend
                         if (Env.IsDevelopment())
                         {
                             builder.WithOrigins(
-                                "http://localhost:8080",
-                                "http://localhost:8080/editor"
+                                "http://*.localhost:8080"
                             )
                             .AllowAnyHeader()
                             .AllowAnyMethod();
@@ -68,12 +67,12 @@ namespace incrementally_backend
                         else
                         {
                             builder.WithOrigins(
-                                "https://incrementally.xyz",
-                                "https://incrementally.xyz/editor"
+                                "https://*.incrementally.xyz"
                             )
                             .AllowAnyHeader()
                             .AllowAnyMethod();
                         }
+                        builder.SetIsOriginAllowedToAllowWildcardSubdomains();
                     });
             });
             services.AddSwaggerGen(c =>


### PR DESCRIPTION
I think this should work well as origin from Incrementally is for example:
https://www.incrementally.xyz/explore
(Note that www is seen as a subdomain here)

/explore and various id's should not affect CORS, according to microsofts azure cors doc.
https://docs.microsoft.com/en-us/aspnet/core/security/cors?view=aspnetcore-3.1#testc 