### PR TITLE
Feature/ab#4 local cosmosdb

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -32,7 +32,12 @@ namespace incrementally_backend
                     new KeyVaultClient.AuthenticationCallback(azureServiceTokenProvider.KeyVaultTokenCallback));
                 builder
                     .AddAzureKeyVault(keyVaultEndpoint, keyVaultClient, new DefaultKeyVaultSecretManager())
-                    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
+                    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                    .AddJsonFile($"appsettings.Development.json", optional: true, reloadOnChange: true);
+                if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development")
+                {
+                    builder.AddUserSecrets<Program>();
+                }
             }
         })
         .UseStartup<Startup>()

--- a/Program.cs
+++ b/Program.cs
@@ -36,6 +36,8 @@ namespace incrementally_backend
                     .AddJsonFile($"appsettings.Development.json", optional: true, reloadOnChange: true);
                 if (Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") == "Development")
                 {
+                    // If this is throwing an exception it's probably because you need to create secrets.json.
+                    // See README for more info.
                     builder.AddUserSecrets<Program>();
                 }
             }

--- a/Startup.cs
+++ b/Startup.cs
@@ -121,7 +121,6 @@ namespace incrementally_backend
             var containerNames = new List<string>();
             configurationSection.GetSection("ContainerNames").Bind(containerNames);
             string account = configurationSection.GetSection("Account").Value;
-            // string key = configurationSection.GetSection("Key").Value;
             string key = configuration["CosmosDBKey"];
             CosmosClientBuilder clientBuilder = new CosmosClientBuilder(account, key);
             CosmosClient client = clientBuilder

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "CosmosDb": {
-    "Account": "https://localhost:8081",
+    "Account": "https://localhost:8081"
    },
   "Logging": {
     "LogLevel": {

--- a/appsettings.Development.json
+++ b/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "CosmosDb": {
+    "Account": "https://localhost:8081",
+   },
   "Logging": {
     "LogLevel": {
       "Default": "Debug",

--- a/incrementally-backend.csproj
+++ b/incrementally-backend.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>incrementally_backend</RootNamespace>
+    <UserSecretsId>96e2f655-d779-41ac-b902-349ea9984dcd</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This pull request implements proper handling for local config so that CosmosDB emulator can be used to test the application, rather than using the production instance.

[AB#4](https://dev.azure.com/incrementally/6e119c52-39a8-4798-85c7-142aed46bee9/_workitems/edit/4)